### PR TITLE
Fixed Bug # 9

### DIFF
--- a/src/multiselect-dropdown.ts
+++ b/src/multiselect-dropdown.ts
@@ -156,6 +156,7 @@ export class MultiselectDropdown implements OnInit, DoCheck, ControlValueAccesso
     ngOnInit() {
         this.settings = Object.assign(this.defaultSettings, this.settings);
         this.texts = Object.assign(this.defaultTexts, this.texts);
+        this.title = this.texts.defaultTitle;
     }
 
     writeValue(value: any) : void {
@@ -193,6 +194,7 @@ export class MultiselectDropdown implements OnInit, DoCheck, ControlValueAccesso
     }
 
     setSelected(event: Event, option: IMultiSelectOption) {
+        if (!this.model) this.model = [];    
         var index = this.model.indexOf(option.id);
         if (index > -1) {
             this.model.splice(index, 1);


### PR DESCRIPTION
Fixed Bug # 9 https://github.com/softsimon/angular-2-dropdown-multiselect/issues/9

Fixed two issues below:
1. If the initial selectedOptions array is empty then setSelected gives an error at "this.model.indexOf" as this.model is undefined
2. If the initial selectedOptions array is empty then the initial heading of the drop down is empty