### PR TITLE
Fix an unhandled exception when using IE

### DIFF
--- a/src/multiselect-dropdown.ts
+++ b/src/multiselect-dropdown.ts
@@ -106,7 +106,7 @@ export class MultiselectDropdown implements OnInit, DoCheck, ControlValueAccesso
     @HostListener('document: click', ['$event.target'])
     onClick(target:HTMLElement) {
         let parentFound = false;
-        while (target !== null && !parentFound) {
+        while (target != null && !parentFound) {
             if (target === this.element.nativeElement) {
                 parentFound = true;
             }


### PR DESCRIPTION
Do not use strict compare of target nullness, this will prevent an exception when target is 'undefined' instead of null.