### PR TITLE
automatically unselect the first selected item when exceeding the sel…

### DIFF
--- a/src/multiselect-dropdown.ts
+++ b/src/multiselect-dropdown.ts
@@ -29,6 +29,7 @@ export interface IMultiSelectSettings {
     buttonClasses?: string;
     selectionLimit?: number;
     closeOnSelect?: boolean;
+    autoUnselect?: boolean;
     showCheckAll?: boolean;
     showUncheckAll?: boolean;
     dynamicTitleMaxItems?: number;
@@ -132,6 +133,7 @@ export class MultiselectDropdown implements OnInit, DoCheck, ControlValueAccesso
         buttonClasses: 'btn btn-default',
         selectionLimit: 0,
         closeOnSelect: false,
+        autoUnselect: false,
         showCheckAll: false,
         showUncheckAll: false,
         dynamicTitleMaxItems: 3,
@@ -202,8 +204,13 @@ export class MultiselectDropdown implements OnInit, DoCheck, ControlValueAccesso
             if (this.settings.selectionLimit === 0 || this.model.length < this.settings.selectionLimit) {
                 this.model.push(option.id);
             } else {
-                this.selectionLimitReached.emit(this.model.length);
-                return;
+                if (this.settings.autoUnselect) {
+                    this.model.push(option.id)
+                    this.model.shift();
+                } else {
+                    this.selectionLimitReached.emit(this.model.length);
+                    return;
+                }
             }
         }
         if (this.settings.closeOnSelect) {


### PR DESCRIPTION
In order to support single selection (which may seem counter-intuitive to this project, but is often requested) as well as a different approach to handling reaching the selection limit I propose this update.

This update introduces a new setting `autoUnselect` which will unselect the oldest selection in order to not exceed the selection limit.

This means for selectionLimit of 1 you have single selection behaviour, and for larger selections the user can easily amend their selections without having to locate their previous selections and uncheck them.
