### PR TITLE
Added output event when closing the drop-down

### DIFF
--- a/src/multiselect-dropdown.ts
+++ b/src/multiselect-dropdown.ts
@@ -120,6 +120,7 @@ export class MultiselectDropdown implements OnInit, DoCheck, ControlValueAccesso
     @Input() settings: IMultiSelectSettings;
     @Input() texts: IMultiSelectTexts;
     @Output() selectionLimitReached = new EventEmitter();
+    @Output() onDropdownClose = new EventEmitter();
 
     @HostListener('document: click', ['$event.target'])
     onClick(target: HTMLElement) {
@@ -206,6 +207,9 @@ export class MultiselectDropdown implements OnInit, DoCheck, ControlValueAccesso
 
     toggleDropdown() {
         this.isVisible = !this.isVisible;
+        if (!this.isVisible) {
+            this.onDropdownClose.emit();
+        }
     }
 
     isSelected(option: IMultiSelectOption): boolean {

--- a/src/multiselect-dropdown.ts
+++ b/src/multiselect-dropdown.ts
@@ -120,7 +120,7 @@ export class MultiselectDropdown implements OnInit, DoCheck, ControlValueAccesso
     @Input() settings: IMultiSelectSettings;
     @Input() texts: IMultiSelectTexts;
     @Output() selectionLimitReached = new EventEmitter();
-    @Output() onDropdownClose = new EventEmitter();
+    @Output() dropdownClosed = new EventEmitter();
 
     @HostListener('document: click', ['$event.target'])
     onClick(target: HTMLElement) {
@@ -208,7 +208,7 @@ export class MultiselectDropdown implements OnInit, DoCheck, ControlValueAccesso
     toggleDropdown() {
         this.isVisible = !this.isVisible;
         if (!this.isVisible) {
-            this.onDropdownClose.emit();
+            this.dropdownClosed.emit();
         }
     }
 


### PR DESCRIPTION
resolves #28 

I've added a simple `EventEmitter` as an output, and emit event when the drop-down is closed using simple condition in `toggleDropdown()` function

in order to use it just add `(dropdownClosed)="someFunctionInYourClass()"`  to the component HTML selector

