### PR TITLE
Style Customization

### DIFF
--- a/src/multiselect-dropdown.ts
+++ b/src/multiselect-dropdown.ts
@@ -35,6 +35,7 @@ export interface IMultiSelectOption {
   name: string;
   isLabel?: boolean;
   parentId?: any;
+  params?: any;
 }
 
 export interface IMultiSelectSettings {
@@ -42,6 +43,7 @@ export interface IMultiSelectSettings {
   enableSearch?: boolean;
   checkedStyle?: 'checkboxes' | 'glyphicon' | 'fontawesome';
   buttonClasses?: string;
+  itemClasses?: string;
   selectionLimit?: number;
   closeOnSelect?: boolean;
   autoUnselect?: boolean;
@@ -129,7 +131,9 @@ export class MultiSelectSearchFilter implements PipeTransform {
             <span *ngIf="settings.checkedStyle === 'fontawesome'" style="width: 16px;display: inline-block;">
   			      <i *ngIf="isSelected(option)" class="fa fa-check" aria-hidden="true"></i>
   			    </span>
-            {{ option.name }}
+            <span [ngClass]="settings.itemClasses">
+              {{ option.name }}
+            </span>
           </a>
         </li>
       </ul>
@@ -346,7 +350,7 @@ export class MultiselectDropdown implements OnInit, DoCheck, ControlValueAccesso
 
 @NgModule({
   imports: [CommonModule, FormsModule],
-  exports: [MultiselectDropdown],
+  exports: [MultiselectDropdown, MultiSelectSearchFilter],
   declarations: [MultiselectDropdown, MultiSelectSearchFilter],
 })
 export class MultiselectDropdownModule {


### PR DESCRIPTION
- Applying classes to `items`
- Allowing a `params` object to be received
- Exporting `pipe` to be used when extending multiselect class



1. `params?: any;`


We can create an object (or send from backend) like this:

```
optionsObj: IMultiSelectOption[] = [
  {
     'id': 1,
     'name': itemName,
     'params': {
       'background': '#333'
      }
  },
  {...}
];
```

And we can then apply whatever change we want by extending the Multiselect class. Like this, for example:

`<a *ngIf="!option.isLabel" class="darkMultiselectLink" [style.background-color]="option.params.background" href="javascript:;" role="menuitem" tabindex="-1">`

In an extended class that will override the library's template, for example:

`export class extendedClass extends MultiselectDropdown {
}`





2. `itemClasses?: string;`


Adding a class to the element (the `<span>`, not the `<a>`). Example: 

`public multiselectSettings: IMultiSelectSettings = {
  itemClasses: 'myClass1 myClass2 myClass3'
};`


 
3. `exports: [MultiselectDropdown, MultiSelectSearchFilter],`



By adding `MultiSelectSearchFilter` to the exports, we can use the Pipe declared in here. Is very useful when extending the class. Example:

`import { MultiselectDropdownModule, MultiSelectSearchFilter } from 'angular-2-dropdown-multiselect';`

`@NgModule({
    declarations: [
        UsersFilterRankMultiselect
    ]
})
`