### PR TITLE
Fixing typescript compilation errors

### DIFF
--- a/src/multiselect-dropdown.ts
+++ b/src/multiselect-dropdown.ts
@@ -249,7 +249,7 @@ export class MultiselectDropdown implements OnInit, DoCheck, ControlValueAccesso
     }
   }
 
-  validate(c: AbstractControl): { [key: string]: any; } {
+  validate(_c: AbstractControl): { [key: string]: any; } {
     return (this.model && this.model.length) ? null : {
       required: {
         valid: false,
@@ -257,7 +257,7 @@ export class MultiselectDropdown implements OnInit, DoCheck, ControlValueAccesso
     };
   }
 
-  registerOnValidatorChange(fn: () => void): void {
+  registerOnValidatorChange(_fn: () => void): void {
     throw new Error('Method not implemented.');
   }
 
@@ -275,7 +275,7 @@ export class MultiselectDropdown implements OnInit, DoCheck, ControlValueAccesso
     return this.model && this.model.indexOf(option.id) > -1;
   }
 
-  setSelected(event: Event, option: IMultiSelectOption) {
+  setSelected(_event: Event, option: IMultiSelectOption) {
     if (!this.model) {
       this.model = [];
     }


### PR DESCRIPTION
TypeScript 2 currently throws the following compilation errors, if a target project uses this module as an import.

```
node_modules/angular-2-dropdown-multiselect/src/multiselect-dropdown.ts(251,12): error TS6133: 'c' is declared but never used.
node_modules/angular-2-dropdown-multiselect/src/multiselect-dropdown.ts(259,29): error TS6133: 'fn' is declared but never used.
node_modules/angular-2-dropdown-multiselect/src/multiselect-dropdown.ts(279,15): error TS6133: 'event' is declared but never used.
```


To reproduce, use tsconfig.json with noUnusedParameters flag.