### PR TITLE
check all  not working when this.model is null

### DIFF
--- a/src/multiselect-dropdown.ts
+++ b/src/multiselect-dropdown.ts
@@ -332,7 +332,7 @@ export class MultiselectDropdown implements OnInit, DoCheck, ControlValueAccesso
   checkAll() {
     this.model = this.options
       .map((option: IMultiSelectOption) => {
-        if (this.model.indexOf(option.id) === -1) {
+        if (this.model==null|| this.model.indexOf(option.id) === -1) {
           this.onAdded.emit(option.id);
         }
         return option.id;


### PR DESCRIPTION
While loading the data through  http service call model is  having null value and breaking the  check all functionality.  Added a fix  to check all data when model is null