### PR TITLE
Allow changing texts input

### DIFF
--- a/package.json
+++ b/package.json
@@ -38,10 +38,10 @@
   "homepage": "http://softsimon.github.io/angular-2-dropdown-multiselect",
   "dependencies": {},
   "peerDependencies": {
-    "tslib": "^1.6.1",
     "@angular/common": "^4.0.0",
     "@angular/core": "^4.0.0",
-    "@angular/forms": "^4.0.0"
+    "@angular/forms": "^4.0.0",
+    "tslib": "^1.6.1"
   },
   "devDependencies": {
     "@angular/common": "^4.0.0",
@@ -49,6 +49,7 @@
     "@angular/compiler-cli": "^4.0.0",
     "@angular/core": "^4.0.0",
     "@angular/forms": "^4.0.0",
+    "@angular/platform-browser": "^4.0.0",
     "@angular/platform-server": "^4.0.0",
     "@types/core-js": "^0.9.41",
     "@types/jasmine": "^2.5.47",

--- a/yarn.lock
+++ b/yarn.lock
@@ -26,6 +26,10 @@
   version "4.1.0"
   resolved "http://eap-dev:8484/@angular%2fforms/-/forms-4.1.0.tgz#8eae2a45c4ba064b377f9280e59c012b5dac6b80"
 
+"@angular/platform-browser@^4.0.0":
+  version "4.1.0"
+  resolved "http://eap-dev:8484/@angular%2fplatform-browser/-/platform-browser-4.1.0.tgz#b981386be1a36f2af7f0679447fd97b7267b25de"
+
 "@angular/platform-server@^4.0.0":
   version "4.1.0"
   resolved "http://eap-dev:8484/@angular%2fplatform-server/-/platform-server-4.1.0.tgz#6100a12fe3e8568c9bf5fc27af79e52aaa71fedb"


### PR DESCRIPTION
This PR allows users to update `texts` input property on dropdown and rerender for example a dropdown placeholder text (In my case I wanted to indicate in placeholder that it loads options and then show normal placeholder).

Also this fixes an error being thrown if you do not set `items` input property from the beginning because there were code which was assuming that items is array by default. So I moved that code from `OnInit` to `OnChanges` and guarded items by default to empty array along with updating `parent` property.

NOTE: There's small change in `updateTitle()` method to properly render title when there are no items and no options yet. Previously in that case it was trying to render from `texts.allSelected` property which is wrong so I just moved first if-block below second one so that `texts.defaultTitle` will be rendered.