### PR TITLE
Prevent propagating click event to parents (and thus closing the drop…

### DIFF
--- a/src/dropdown/dropdown.component.ts
+++ b/src/dropdown/dropdown.component.ts
@@ -182,7 +182,7 @@ export class MultiselectDropdown implements OnInit, OnChanges, DoCheck, ControlV
   }
 
   setSelected(_event: Event, option: IMultiSelectOption) {
-    event.stopPropagation();
+    _event.stopPropagation();
     if (!this.model) {
       this.model = [];
     }

--- a/src/dropdown/dropdown.component.ts
+++ b/src/dropdown/dropdown.component.ts
@@ -182,6 +182,7 @@ export class MultiselectDropdown implements OnInit, OnChanges, DoCheck, ControlV
   }
 
   setSelected(_event: Event, option: IMultiSelectOption) {
+    event.stopPropagation();
     if (!this.model) {
       this.model = [];
     }


### PR DESCRIPTION
Prevent propagating click event to parents (and thus closing the dropdown)
Fix for #5