### PR TITLE
Add ability to limit rendering of large items

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,8 +40,10 @@ import { IMultiSelectOption } from 'angular-2-dropdown-multiselect';
 
 export class MyClass implements OnInit {
     optionsModel: number[];
+    myOptions: IMultiSelectOption[];
+
     ngOnInit() {
-        myOptions: IMultiSelectOption[] = [
+        this.myOptions = [
             { id: 1, name: 'Option 1' },
             { id: 2, name: 'Option 2' },
         ];

--- a/README.md
+++ b/README.md
@@ -123,6 +123,8 @@ myOptions: IMultiSelectOption[] = [
 | dynamicTitleMaxItems | The maximum number of options to display in the dynamic title      | 3                 |
 | maxHeight            | The maximum height for the dropdown (including unit)               | '300px'           |
 | displayAllSelectedText | Display the `allSelected` text when all options are selected    | false             |
+| searchRenderLimit    | If `enableSearch=true` and total amount of items more then `searchRenderLimit` (0 - No limit) then render items only when user typed more then or equal `searchRenderAfter` charachters    | 0             |
+| searchRenderAfter    | Amount of characters to trigger rendering of items                 | 3                 |
 
 ### Texts
 | Text Item             | Description                                | Default Value     |
@@ -134,6 +136,8 @@ myOptions: IMultiSelectOption[] = [
 | searchPlaceholder     | Text initially displayed in search input   | 'Search...'       |
 | defaultTitle          | Title displayed in button before selection | 'Select'          |
 | allSelected           | Text displayed when all items are selected (must be enabled in options) | 'All selected' |
+| saerchEmptyResult     | Text displayed when no items are rendered  | 'Nothing found...' |
+| searchNoRenderText    | Text displayed when items rendering disabled by the `searchRenderLimit` option | 'Type in search box to see results...' |
 
 ## Other examples
 

--- a/src/dropdown/dropdown.component.html
+++ b/src/dropdown/dropdown.component.html
@@ -5,9 +5,8 @@
     <li class="dropdown-item search" *ngIf="settings.enableSearch">
       <div class="input-group input-group-sm">
         <span class="input-group-addon" id="sizing-addon3"><i class="fa fa-search"></i></span>
-        <input type="text" class="form-control" placeholder="{{ texts.searchPlaceholder }}" aria-describedby="sizing-addon3" [(ngModel)]="searchFilterText"
-          [ngModelOptions]="{standalone: true}" autofocus>
-        <span class="input-group-btn" *ngIf="searchFilterText.length > 0">
+        <input type="text" class="form-control" placeholder="{{ texts.searchPlaceholder }}" aria-describedby="sizing-addon3" [formControl]="filterControl" autofocus>
+        <span class="input-group-btn" *ngIf="filterControl.value.length > 0">
           <button class="btn btn-default btn-secondary" type="button" (click)="clearSearch($event)"><i class="fa fa-times"></i></button>
         </span>
       </div>
@@ -26,19 +25,27 @@
       </a>
     </li>
     <li *ngIf="settings.showCheckAll || settings.showUncheckAll" class="dropdown-divider divider"></li>
-    <li class="dropdown-item" [ngStyle]="getItemStyle(option)" *ngFor="let option of options | searchFilter:searchFilterText"
-      (click)="!option.isLabel && setSelected($event, option)" [class.dropdown-header]="option.isLabel">
-      <ng-template [ngIf]="option.isLabel">{{ option.name }}</ng-template>
-      <a *ngIf="!option.isLabel" href="javascript:;" role="menuitem" tabindex="-1" [style.padding-left]="this.parents.length>0&&this.parents.indexOf(option.id)<0&&'30px'">
-        <input *ngIf="settings.checkedStyle === 'checkboxes'" type="checkbox" [checked]="isSelected(option)" (click)="preventCheckboxCheck($event, option)"/>
-        <span *ngIf="settings.checkedStyle === 'glyphicon'" style="width: 16px;" class="glyphicon" [class.glyphicon-ok]="isSelected(option)"></span>
-        <span *ngIf="settings.checkedStyle === 'fontawesome'" style="width: 16px;display: inline-block;">
-          <i *ngIf="isSelected(option)" class="fa fa-check" aria-hidden="true"></i>
-        </span>
-        <span [ngClass]="settings.itemClasses" [style.font-weight]="this.parents.indexOf(option.id)>=0?'bold':'normal'">
-          {{ option.name }}
-        </span>
-      </a>
-    </li>
+    <ng-template [ngIf]="renderItems" [ngIfElse]="noRenderBlock">
+      <ng-template [ngIf]="options | searchFilter:filterControl.value" let-filteredOptions>
+        <li *ngIf="!filteredOptions.length" class="dropdown-item empty">{{ texts.saerchEmptyResult }}</li>
+        <li class="dropdown-item" [ngStyle]="getItemStyle(option)" *ngFor="let option of filteredOptions" (click)="!option.isLabel && setSelected($event, option)"
+          [class.dropdown-header]="option.isLabel">
+          <ng-template [ngIf]="option.isLabel">{{ option.name }}</ng-template>
+          <a *ngIf="!option.isLabel" href="javascript:;" role="menuitem" tabindex="-1" [style.padding-left]="this.parents.length>0&&this.parents.indexOf(option.id)<0&&'30px'">
+            <input *ngIf="settings.checkedStyle === 'checkboxes'" type="checkbox" [checked]="isSelected(option)" (click)="preventCheckboxCheck($event, option)"/>
+            <span *ngIf="settings.checkedStyle === 'glyphicon'" style="width: 16px;" class="glyphicon" [class.glyphicon-ok]="isSelected(option)"></span>
+            <span *ngIf="settings.checkedStyle === 'fontawesome'" style="width: 16px;display: inline-block;">
+              <i *ngIf="isSelected(option)" class="fa fa-check" aria-hidden="true"></i>
+            </span>
+            <span [ngClass]="settings.itemClasses" [style.font-weight]="this.parents.indexOf(option.id)>=0?'bold':'normal'">
+              {{ option.name }}
+            </span>
+          </a>
+        </li>
+      </ng-template>
+    </ng-template>
+    <ng-template #noRenderBlock>
+      <li class="dropdown-item empty">{{ texts.searchNoRenderText }}</li>
+    </ng-template>
   </ul>
 </div>

--- a/src/dropdown/dropdown.module.ts
+++ b/src/dropdown/dropdown.module.ts
@@ -2,10 +2,10 @@ import { MultiselectDropdown } from './dropdown.component';
 import { MultiSelectSearchFilter } from './search-filter.pipe';
 import { CommonModule } from '@angular/common';
 import { NgModule } from '@angular/core';
-import { FormsModule } from '@angular/forms';
+import { ReactiveFormsModule } from '@angular/forms';
 
 @NgModule({
-  imports: [CommonModule, FormsModule],
+  imports: [CommonModule, ReactiveFormsModule],
   exports: [MultiselectDropdown, MultiSelectSearchFilter],
   declarations: [MultiselectDropdown, MultiSelectSearchFilter],
 })

--- a/src/dropdown/types.ts
+++ b/src/dropdown/types.ts
@@ -9,6 +9,16 @@ export interface IMultiSelectOption {
 export interface IMultiSelectSettings {
   pullRight?: boolean;
   enableSearch?: boolean;
+  /**
+   * 0 - By default
+   * If `enableSearch=true` and total amount of items more then `searchRenderLimit` (0 - No limit)
+   * then render items only when user typed more then or equal `searchRenderAfter` charachters
+   */
+  searchRenderLimit?: number;
+  /**
+   * 3 - By default
+   */
+  searchRenderAfter?: number;
   checkedStyle?: 'checkboxes' | 'glyphicon' | 'fontawesome';
   buttonClasses?: string;
   itemClasses?: string;
@@ -30,6 +40,8 @@ export interface IMultiSelectTexts {
   checked?: string;
   checkedPlural?: string;
   searchPlaceholder?: string;
+  saerchEmptyResult?: string;
+  searchNoRenderText?: string;
   defaultTitle?: string;
   allSelected?: string;
 }


### PR DESCRIPTION
I ran into a performance issue when there are >10000 items in the dropdown it opens quite slow (~2s delay).

I came up with an idea to postpone rendering of items unless user will type something in the filter to reduce amount of items rendered.

This also make sense because users most likely won't scroll through such a big dropdowns but immediately filter them.

I added 2 more properties to settings:
* `searchRenderLimit: number`
  0 - By default
  If `enableSearch=true` and total amount of items more then `searchRenderLimit` (0 - No limit)
  then render items only when user typed more then or equal `searchRenderAfter` characters
* `searchRenderAfter: number`
  3 - By default

Also I added 2 more texts:
* `saerchEmptyResult`
  Nothing found... - by default
  Will be shown when no items are found
* `searchNoRenderText`
  Type in search box to see results... - by default
  Will be shown when rendering is disabled by the `searchRenderLimit` option

I updated README.md accordingly to reflect the changes.

Thanks!