### PR TITLE
Don't import entire rxjs/Rx

### DIFF
--- a/src/dropdown/dropdown.component.ts
+++ b/src/dropdown/dropdown.component.ts
@@ -22,7 +22,8 @@ import {
   SimpleChanges,
 } from '@angular/core';
 import { AbstractControl, ControlValueAccessor, FormBuilder, NG_VALUE_ACCESSOR, Validator, FormControl } from '@angular/forms';
-import { Subject } from 'rxjs/Rx';
+import { Subject } from 'rxjs/Subject';
+import 'rxjs/add/operator/takeUntil';
 
 const MULTISELECT_VALUE_ACCESSOR: any = {
   provide: NG_VALUE_ACCESSOR,


### PR DESCRIPTION
Hello. 
```ts
import { Modue } from 'rxjs/Rx';
```
This imports the entire RxJS library.

Changing it to
```ts
import { Subject } from 'rxjs/Subject';
import 'rxjs/add/operator/takeUntil';
```
allows to reduce the file size of a build.

After this change, the file size of my final build decreased by **164kb (-68.62%)**.

Before:
<img src="https://i.imgur.com/eLuAZvz.png" width="80%">
After:
<img src="https://i.imgur.com/WJDF5KW.png" width="80%">