### PR TITLE
Lazy load

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,8 @@
 node_modules
 src/*.js
 src/*.js.map
+src/dropdown/*.js
+src/dropdown/*.js.map
 /compiled
 *.metadata.json
 *.map.js

--- a/src/dropdown/dropdown.component.html
+++ b/src/dropdown/dropdown.component.html
@@ -1,6 +1,9 @@
 <div class="dropdown" [ngClass]="settings.containerClasses" [class.open]="isVisible">
   <button type="button" class="dropdown-toggle" [ngClass]="settings.buttonClasses" (click)="toggleDropdown()" [disabled]="disabled">{{ title }}<span class="caret"></span></button>
-  <ul *ngIf="isVisible" class="dropdown-menu" [class.pull-right]="settings.pullRight" [class.dropdown-menu-right]="settings.pullRight"
+  <ul #scroller *ngIf="isVisible" class="dropdown-menu"
+      (scroll)="settings.isLazyLoad ? checkScrollPosition($event) : null"
+      (wheel)="settings.stopScrollPropagation ? checkScrollPropagation($event, scroller) : null"
+      [class.pull-right]="settings.pullRight" [class.dropdown-menu-right]="settings.pullRight"
       [style.max-height]="settings.maxHeight" style="display: block; height: auto; overflow-y: auto;">
     <li class="dropdown-item search" *ngIf="settings.enableSearch">
       <div class="input-group input-group-sm">
@@ -26,7 +29,7 @@
     </li>
     <li *ngIf="settings.showCheckAll || settings.showUncheckAll" class="dropdown-divider divider"></li>
     <ng-template [ngIf]="renderItems" [ngIfElse]="noRenderBlock">
-      <ng-template [ngIf]="options | searchFilter:filterControl.value" let-filteredOptions>
+      <ng-template [ngIf]="options | searchFilter:(!settings.isLazyLoad ? filterControl.value : '')" let-filteredOptions>
         <li *ngIf="!filteredOptions.length" class="dropdown-item empty">{{ texts.saerchEmptyResult }}</li>
         <li class="dropdown-item" [ngStyle]="getItemStyle(option)" *ngFor="let option of filteredOptions" (click)="!option.isLabel && setSelected($event, option)"
           [class.dropdown-header]="option.isLabel">

--- a/src/dropdown/dropdown.component.ts
+++ b/src/dropdown/dropdown.component.ts
@@ -91,8 +91,8 @@ export class MultiselectDropdown implements OnInit, OnChanges, DoCheck, OnDestro
     fixedTitle: false,
     dynamicTitleMaxItems: 3,
     maxHeight: '300px',
-    isLazyLoad: true,
-    stopScrollPropagation: true,
+    isLazyLoad: false,
+    stopScrollPropagation: false,
     loadViewDistance: 1
   };
   defaultTexts: IMultiSelectTexts = {

--- a/src/dropdown/dropdown.component.ts
+++ b/src/dropdown/dropdown.component.ts
@@ -47,6 +47,7 @@ export class MultiselectDropdown implements OnInit, OnChanges, DoCheck, OnDestro
   @Output() dropdownOpened = new EventEmitter();
   @Output() onAdded = new EventEmitter();
   @Output() onRemoved = new EventEmitter();
+  @Output() onLazyLoad = new EventEmitter();
 
   @HostListener('document: click', ['$event.target'])
   onClick(target: HTMLElement) {
@@ -89,7 +90,10 @@ export class MultiselectDropdown implements OnInit, OnChanges, DoCheck, OnDestro
     showUncheckAll: false,
     fixedTitle: false,
     dynamicTitleMaxItems: 3,
-    maxHeight: '300px'
+    maxHeight: '300px',
+    isLazyLoad: true,
+    stopScrollPropagation: true,
+    loadViewDistance: 1
   };
   defaultTexts: IMultiSelectTexts = {
     checkAll: 'Check all',
@@ -136,14 +140,19 @@ export class MultiselectDropdown implements OnInit, OnChanges, DoCheck, OnDestro
   }
 
 
-  ngOnInit() {console.log("in copy")
+  ngOnInit() {
     this.settings = Object.assign(this.defaultSettings, this.settings);
     this.texts = Object.assign(this.defaultTexts, this.texts);
     this.title = this.texts.defaultTitle || '';
 
     this.filterControl.valueChanges
       .takeUntil(this.destroyed$)
-      .subscribe(() => this.updateRenderItems());
+      .subscribe(function() {
+        this.updateRenderItems();
+        if (this.settings.isLazyLoad) {
+          this.load();
+        }
+      }.bind(this));
   }
 
   ngOnChanges(changes: SimpleChanges) {
@@ -359,6 +368,35 @@ export class MultiselectDropdown implements OnInit, OnChanges, DoCheck, OnDestro
 
   isCheckboxDisabled(): boolean {
     return this.disabledSelection;
+  }
+
+  checkScrollPosition(ev) {
+    let scrollTop = ev.target.scrollTop;
+    let scrollHeight = ev.target.scrollHeight;
+    let scrollElementHeight = ev.target.clientHeight;
+
+    if (scrollTop >= scrollHeight - (1 + this.settings.loadViewDistance)*scrollElementHeight - 2) {
+      this.load();
+    }
+  }
+
+  checkScrollPropagation(ev, element) {
+    let scrollTop = element.scrollTop;
+    let scrollHeight = element.scrollHeight;
+    let scrollElementHeight = element.clientHeight;
+
+    if ((ev.deltaY > 0 && scrollTop + scrollElementHeight >= scrollHeight) || (ev.deltaY < 0 && scrollTop <= 0)) {
+      ev = ev || window.event;
+      ev.preventDefault && ev.preventDefault();
+      ev.returnValue = false;
+    }
+  }
+
+  load() {
+    this.onLazyLoad.emit({
+      length: this.options.length,
+      filter: this.filterControl.value
+    });
   }
 
 }

--- a/src/dropdown/dropdown.component.ts
+++ b/src/dropdown/dropdown.component.ts
@@ -136,7 +136,7 @@ export class MultiselectDropdown implements OnInit, OnChanges, DoCheck, OnDestro
   }
 
 
-  ngOnInit() {
+  ngOnInit() {console.log("in copy")
     this.settings = Object.assign(this.defaultSettings, this.settings);
     this.texts = Object.assign(this.defaultTexts, this.texts);
     this.title = this.texts.defaultTitle || '';

--- a/src/dropdown/dropdown.component.ts
+++ b/src/dropdown/dropdown.component.ts
@@ -374,8 +374,10 @@ export class MultiselectDropdown implements OnInit, OnChanges, DoCheck, OnDestro
     let scrollTop = ev.target.scrollTop;
     let scrollHeight = ev.target.scrollHeight;
     let scrollElementHeight = ev.target.clientHeight;
+    let roundingPixel = 1;
+    let gutterPixel = 1;
 
-    if (scrollTop >= scrollHeight - (1 + this.settings.loadViewDistance)*scrollElementHeight - 2) {
+    if (scrollTop >= scrollHeight - (1 + this.settings.loadViewDistance)*scrollElementHeight - roundingPixel - gutterPixel) {
       this.load();
     }
   }

--- a/src/dropdown/types.ts
+++ b/src/dropdown/types.ts
@@ -31,7 +31,10 @@ export interface IMultiSelectSettings {
   fixedTitle?: boolean;
   dynamicTitleMaxItems?: number;
   maxHeight?: string;
-  displayAllSelectedText?: boolean
+  displayAllSelectedText?: boolean;
+  isLazyLoad?: boolean;
+  loadViewDistance?: number;
+  stopScrollPropagation?: boolean;
 }
 
 export interface IMultiSelectTexts {


### PR DESCRIPTION
Adds the ability to lazy load data on scrolling from a service to populate the dropdown. Also adds the option to freeze the dropdown menu from wheel scrolling overflow -- when the dropdown reaches bottom or top, the page behind it won't start scrolling. The user must move out of the dropdown window to scroll the page. 

The property, ```loadViewDistance```, is the number of dropdown div heights from the bottom the user must be before the ```onLazyLoad``` event fires. On a value of ```1```, the lazy load triggers when the dropdown is within one dropdown div height from the bottom. On a value of ```0```, the user must scroll all the way to the bottom for the event to trigger. The ```onLazyLoad``` event provides the current total number of options displayed as well as the current search string. If using search during lazy load, the search must be provided through the data service. Otherwise, the service won't know how many matches to provide. For example, if items were loaded ten at a time, all of them could match the search criterion, or none of them could.

Would it also be possible for me to access http://softsimon.github.io/angular-2-dropdown-multiselect/ to fork and add an example for this feature?