### PR TITLE
Configurable option for the minimum number of allowed items selected

### DIFF
--- a/src/dropdown/dropdown.component.ts
+++ b/src/dropdown/dropdown.component.ts
@@ -86,6 +86,7 @@ export class MultiselectDropdown implements OnInit, OnChanges, DoCheck, OnDestro
     buttonClasses: 'btn btn-default btn-secondary',
     containerClasses: 'dropdown-inline',
     selectionLimit: 0,
+    minSelectionLimit: 0,
     closeOnSelect: false,
     autoUnselect: false,
     showCheckAll: false,
@@ -242,8 +243,10 @@ export class MultiselectDropdown implements OnInit, OnChanges, DoCheck, OnDestro
       }
       const index = this.model.indexOf(option.id);
       if (index > -1) {
-        this.model.splice(index, 1);
-        this.onRemoved.emit(option.id);
+        if ((this.settings.minSelectionLimit === undefined) || (this.numSelected > this.settings.minSelectionLimit)) {
+          this.model.splice(index, 1);
+          this.onRemoved.emit(option.id);
+        }
         const parentIndex = option.parentId && this.model.indexOf(option.parentId);
         if (parentIndex >= 0) {
           this.model.splice(parentIndex, 1);
@@ -341,7 +344,7 @@ export class MultiselectDropdown implements OnInit, OnChanges, DoCheck, OnDestro
           : (new MultiSelectSearchFilter()).transform(this.options, this.filterControl.value).map((option: IMultiSelectOption) => option.id)
       );
       this.model = this.model.filter((id: number) => {
-        if (unCheckedOptions.indexOf(id) < 0) {
+        if (((unCheckedOptions_1.indexOf(id) < 0) && (_this.settings.minSelectionLimit === undefined)) || ((unCheckedOptions_1.indexOf(id) < _this.settings.minSelectionLimit))) {
           return true;
         } else {
           this.onRemoved.emit(id);

--- a/src/dropdown/types.ts
+++ b/src/dropdown/types.ts
@@ -36,6 +36,7 @@ export interface IMultiSelectSettings {
   itemClasses?: string;
   containerClasses?: string;
   selectionLimit?: number;
+  minSelectionLimit?: number;
   closeOnSelect?: boolean;
   autoUnselect?: boolean;
   showCheckAll?: boolean;


### PR DESCRIPTION
Hi,

This pull request adds the option to have a minimum number of selected items in a list. This feature has been requested in issue #214. This feature works by disallowing unselecting the last x number of items if this options is configured. This can configured in the new option 'minSelectionLimit'. The unselectall button also respects this setting.

