### PR TITLE
Correct typo of saerchEmptyResult to searchEmptyResult

### DIFF
--- a/README.md
+++ b/README.md
@@ -140,7 +140,7 @@ myOptions: IMultiSelectOption[] = [
 | searchPlaceholder     | Text initially displayed in search input   | 'Search...'       |
 | defaultTitle          | Title displayed in button before selection | 'Select'          |
 | allSelected           | Text displayed when all items are selected (must be enabled in options) | 'All selected' |
-| saerchEmptyResult     | Text displayed when no items are rendered  | 'Nothing found...' |
+| searchEmptyResult     | Text displayed when no items are rendered  | 'Nothing found...' |
 | searchNoRenderText    | Text displayed when items rendering disabled by the `searchRenderLimit` option | 'Type in search box to see results...' |
 
 ## Other examples

--- a/src/dropdown/dropdown.component.html
+++ b/src/dropdown/dropdown.component.html
@@ -30,7 +30,7 @@
     </li>
     <li *ngIf="settings.showCheckAll || settings.showUncheckAll" class="dropdown-divider divider"></li>
     <li *ngIf="!renderItems" class="dropdown-item empty">{{ texts.searchNoRenderText }}</li>
-    <li *ngIf="renderItems && !renderFilteredOptions.length" class="dropdown-item empty">{{ texts.saerchEmptyResult }}</li>
+    <li *ngIf="renderItems && !renderFilteredOptions.length" class="dropdown-item empty">{{ texts.searchEmptyResult }}</li>
     <li class="dropdown-item" [ngStyle]="getItemStyle(option)" *ngFor="let option of renderFilteredOptions" [class.dropdown-header]="option.isLabel" [ngClass]="option.classes">
       <a *ngIf="!option.isLabel; else label" href="javascript:;" (click)="setSelected($event, option)" role="menuitem" tabindex="-1"
         [style.padding-left]="this.parents.length>0&&this.parents.indexOf(option.id)<0&&'30px'" [ngStyle]="getItemStyleSelectionDisabled()">

--- a/src/dropdown/dropdown.component.ts
+++ b/src/dropdown/dropdown.component.ts
@@ -130,7 +130,7 @@ export class MultiselectDropdown implements OnInit, OnChanges, DoCheck, OnDestro
     checked: 'checked',
     checkedPlural: 'checked',
     searchPlaceholder: 'Search...',
-    saerchEmptyResult: 'Nothing found...',
+    searchEmptyResult: 'Nothing found...',
     searchNoRenderText: 'Type in search box to see results...',
     defaultTitle: 'Select',
     allSelected: 'All selected',

--- a/src/dropdown/types.ts
+++ b/src/dropdown/types.ts
@@ -57,7 +57,7 @@ export interface IMultiSelectTexts {
   checked?: string;
   checkedPlural?: string;
   searchPlaceholder?: string;
-  saerchEmptyResult?: string;
+  searchEmptyResult?: string;
   searchNoRenderText?: string;
   defaultTitle?: string;
   allSelected?: string;


### PR DESCRIPTION
Code and documentation for 'searchEmptyResult' configuration is misspelled. This fixes the typo in all places.