### PR TITLE
Adding missing text keys to documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,6 +84,8 @@ myTexts: IMultiSelectTexts = {
     checked: 'item selected',
     checkedPlural: 'items selected',
     searchPlaceholder: 'Find',
+    searchEmptyResult: 'Nothing found...',
+    searchNoRenderText: 'Type in search box to see results...',
     defaultTitle: 'Select',
     allSelected: 'All selected',
 };


### PR DESCRIPTION
`searchEmptyResult` and `searchNoRenderText` from IMultiSelectTexts were not documented.