### PR TITLE
Lazy load select all

### DIFF
--- a/src/dropdown/dropdown.component.ts
+++ b/src/dropdown/dropdown.component.ts
@@ -220,14 +220,13 @@ export class MultiselectDropdown implements OnInit, OnChanges, DoCheck, OnDestro
       if (this.texts) {
         this.updateTitle();
       }
+
+      this.onModelChange(this.model);
+      this.onModelTouched();
     }
 
     if (changes['texts'] && !changes['texts'].isFirstChange()) {
       this.updateTitle();
-    }
-    if (this.settings.selectAddedValues && changes.options.previousValue) {
-      this.onModelChange(this.model);
-      this.onModelTouched();
     }
   }
 

--- a/src/dropdown/types.ts
+++ b/src/dropdown/types.ts
@@ -49,6 +49,7 @@ export interface IMultiSelectSettings {
   isLazyLoad?: boolean;
   loadViewDistance?: number;
   stopScrollPropagation?: boolean;
+  selectAddedValues?: boolean;
 }
 
 export interface IMultiSelectTexts {


### PR DESCRIPTION
Select all will currently only select what is loaded and displayed. This change will continue to apply "Check All", including those done during searches, to new data that is loaded in either on scroll or on search.

Applying "Check All" during a search will accumulate that search to a register. Multiple searches with "Check All" will all be stored and applied.

"Uncheck All" during a search will clear that particular search pattern. A search that matches more than one "Check All" will only be cleared when all matching searches have been cleared.

Applying "Check All" with no search criteria clears all individual check all registers and will check everything. A ```checkAllStatus``` boolean stores when this has been set.

Applying "Uncheck All" with no search criteria also clears all search pattern registers as well as clearing all checks .

I will next write a plunkr to demo this as well as update the ReadMe to explain the use of the new functions. Hopefully soon, I would like to write component tests for all features to prevent regression errors.