### PR TITLE
Instructions for lazy loading

### DIFF
--- a/README.md
+++ b/README.md
@@ -131,6 +131,9 @@ myOptions: IMultiSelectOption[] = [
 | searchMaxRenderedItems | Used with searchMaxLimit to further limit rendering for optimization. Should be less than searchMaxLimit to take effect | 0             |
 | displayAllSelectedText | Display the `allSelected` text when all options are selected     | false             |
 | closeOnClickOutside  | Close dropdown when clicked outside                                | true              |
+| isLazyLoad           | An event, ```onLazyLoad```, triggers on scrolling to a specified distance from the bottom of the dropdown, allowing additional data to load | false             |
+| loadViewDistance     | Distance from bottom of dropdown to trigger lazy load, in units of dropdown viewport height | 1             |
+| stopScrollPropagation | Scrolling the dropdown will not overflow to document              | false             |
 
 ### Texts
 | Text Item             | Description                                | Default Value     |
@@ -157,6 +160,12 @@ Although this dropdown is designed for multiple selections, a common request is 
   ...
 }
 ```
+
+### Lazy Loading
+
+This Plunker link demonstrates an implementation of lazy loading: [Lazy loading Plunker](https://plnkr.co/edit/fsZHbth4kzLI79hohcMG?p=preview)
+
+If using search during lazy load, the search term must be supplied to the back end to return the appropriate number of results. Standard inline search will not work, since the front end does not know how many items to load to retrieve the desired number of matches.
 
 ### Use model driven forms with ReactiveFormsModule:
 


### PR DESCRIPTION
This is the first set of instructions for lazy loading, including an example Plunker showing how it is used. When ```selectedAddedValues``` is released, I'll be able to update the Plunker to include the added functionality, and I'll also add a section in the ReadMe about the select all functionality as well as other requirements for using it.