### PR TITLE
Deselect all bug

### DIFF
--- a/src/dropdown/dropdown.component.ts
+++ b/src/dropdown/dropdown.component.ts
@@ -432,7 +432,7 @@ export class MultiselectDropdown implements OnInit, OnChanges, DoCheck, OnDestro
         : this.filteredOptions.map((option: IMultiSelectOption) => option.id)
       );
       // set unchecked options only to the ones that were checked
-      unCheckedOptions = checkedOptions.filter(item => unCheckedOptions.includes(item));
+      unCheckedOptions = checkedOptions.filter(item => this.model.includes(item));
       this.model = this.model.filter((id: number) => {
         if (((unCheckedOptions.indexOf(id) < 0) && (this.settings.minSelectionLimit === undefined)) || ((unCheckedOptions.indexOf(id) < this.settings.minSelectionLimit))) {
           return true;


### PR DESCRIPTION
Bug fix. If a user checks "Select All" with a search filter applied, with ```isLazyLoad``` set to ```true``` and ```selectAddedValues``` set to ```true```, when they scroll in new lazy load values, those matching values will also check. If they then change the search filter selection such that all selected values are no longer showing, then return to that same search and select "Uncheck All", any value previously checked that is currently not showing will not be unchecked. As the user scrolls in lazy load values, the incoming values that were previously checked remain checked when they should be unchecked. This branch fixes that bug.