### PR TITLE
In updateNumSelected ignore blank ids in this.model

### DIFF
--- a/src/dropdown/dropdown.component.ts
+++ b/src/dropdown/dropdown.component.ts
@@ -383,7 +383,7 @@ export class MultiselectDropdown implements OnInit, OnChanges, DoCheck, OnDestro
   }
 
   updateNumSelected() {
-    this.numSelected = this.model.filter(id => this.parents.indexOf(id) < 0).length || 0;
+    this.numSelected = this.model.filter(id => id != '' && this.parents.indexOf(id) < 0).length || 0;
   }
 
   updateTitle() {


### PR DESCRIPTION
Stumbled across this when replacing the options after initialization and the bug was that the default title wouldn't show (the title of the dropdown was simply empty) because the component thought there was something selected (which wasn't). I couldn't fully figure why this model would be set to `[""]`, maybe someone else can?