### PR TITLE
Adds 'maintainSelectionOrderInTitle' setting.

### DIFF
--- a/README.md
+++ b/README.md
@@ -137,6 +137,7 @@ myOptions: IMultiSelectOption[] = [
 | stopScrollPropagation | Scrolling the dropdown will not overflow to document              | false             |
 | selectAddedValues    | Additional lazy loaded ```Select All``` values are checked when added on scrolling | false             |
 | ignoreLabels         | Ignore label options when counting selected options                | false             |
+| maintainSelectionOrderInTitle | The title will show selections in the order they were selected   | false             |
 
 ### Texts
 | Text Item             | Description                                | Default Value     |

--- a/src/dropdown/dropdown.component.ts
+++ b/src/dropdown/dropdown.component.ts
@@ -142,6 +142,7 @@ export class MultiselectDropdown
     loadViewDistance: 1,
     selectAddedValues: false,
     ignoreLabels: false,
+    maintainSelectionOrderInTitle: false,
   };
   defaultTexts: IMultiSelectTexts = {
     checkAll: 'Check all',
@@ -477,16 +478,24 @@ export class MultiselectDropdown
       this.settings.dynamicTitleMaxItems &&
       this.settings.dynamicTitleMaxItems >= this.numSelected
     ) {
-      let useOptions =
+      let useOptions = 
         this.settings.isLazyLoad && this.lazyLoadOptions.length
-          ? this.lazyLoadOptions
-          : this.options;
-      this.title = useOptions
-        .filter(
-          (option: IMultiSelectOption) => this.model.indexOf(option.id) > -1
-        )
-        .map((option: IMultiSelectOption) => option.name)
-        .join(', ');
+        ? this.lazyLoadOptions
+        : this.options;
+
+      let titleSelections: Array<IMultiSelectOption>;
+
+      if (this.settings.maintainSelectionOrderInTitle) {
+          const optionIds = useOptions.map((selectOption: IMultiSelectOption, idx: number) => selectOption.id);
+          titleSelections = this.model
+            .map((selectedId) => optionIds.indexOf(selectedId))
+            .filter((optionIndex) => optionIndex > -1)
+            .map((optionIndex) => useOptions[optionIndex]);
+      } else {
+        titleSelections = useOptions.filter((option: IMultiSelectOption) => this.model.indexOf(option.id) > -1);
+      }
+
+      this.title = titleSelections.map((option: IMultiSelectOption) => option.name).join(', ');
     } else {
       this.title =
         this.numSelected +

--- a/src/dropdown/types.ts
+++ b/src/dropdown/types.ts
@@ -56,6 +56,11 @@ export interface IMultiSelectSettings {
    * If activated label IDs don't count and won't be written to the model.
    */
   ignoreLabels?: boolean;
+  /**
+   * false - By default
+   * If activated, the title will show selections in the order they were selected.
+   */
+  maintainSelectionOrderInTitle?: boolean;
 }
 
 export interface IMultiSelectTexts {


### PR DESCRIPTION
* Default is false, maintaining existing functionality
* When true, the dropdown title will display selections in the order they were selected

PR for: #366 