### PR TITLE
Add support to IMultiSelectOption for disabled and the supporting UI/UX to obey it

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# AngularX Dropdown Multiselect for Bootstrap CSS
+# AngularX Dropdown Multiselect for Bootstrap CSS 
 
 Works with Angular Final and AOT compilation
 

--- a/src/dropdown/dropdown.component.html
+++ b/src/dropdown/dropdown.component.html
@@ -38,7 +38,6 @@
     <li *ngIf="settings.showCheckAll || settings.showUncheckAll" class="dropdown-divider divider"></li>
     <li *ngIf="!renderItems" class="dropdown-item empty">{{ texts.searchNoRenderText }}</li>
     <li *ngIf="renderItems && !renderFilteredOptions.length" class="dropdown-item empty">{{ texts.searchEmptyResult }}</li>
-<<<<<<< HEAD
     <li class="dropdown-item" *ngFor="let option of renderFilteredOptions" [ngClass]="{'active': isSelected(option) }" [ngStyle]="getItemStyle(option)"
       [ngClass]="option.classes" [class.dropdown-header]="option.isLabel" [ssAutofocus]="option !== focusedItem" tabindex="-1"
       (click)="setSelected($event, option)" (keydown.space)="setSelected($event, option)" (keydown.enter)="setSelected($event, option)">
@@ -46,10 +45,11 @@
         [ngStyle]="getItemStyleSelectionDisabled()">
         <ng-container [ngSwitch]="settings.checkedStyle">
           <input *ngSwitchCase="'checkboxes'" type="checkbox" [checked]="isSelected(option)" (click)="preventCheckboxCheck($event, option)"
-            [disabled]="isCheckboxDisabled()" [ngStyle]="getItemStyleSelectionDisabled()" />
-          <span *ngSwitchCase="'glyphicon'" style="width: 16px;" class="glyphicon" [class.glyphicon-ok]="isSelected(option)"></span>
+            [disabled]="isCheckboxDisabled(option)" [ngStyle]="getItemStyleSelectionDisabled()" />
+          <span *ngSwitchCase="'glyphicon'" style="width: 16px;" class="glyphicon" [class.glyphicon-ok]="isSelected(option)" [class.glyphicon-lock]="isCheckboxDisabled(option)"></span>
           <span *ngSwitchCase="'fontawesome'" style="width: 16px;display: inline-block;">
             <i *ngIf="isSelected(option)" class="fa fa-check" aria-hidden="true"></i>
+            <i *ngIf="isCheckboxDisabled(option)" class="fa fa-lock" aria-hidden="true"></i>
           </span>
           <span *ngSwitchCase="'visual'" style="display:block;float:left; border-radius: 0.2em; border: 0.1em solid rgba(44, 44, 44, 0.63);background:rgba(0, 0, 0, 0.1);width: 5.5em;">
             <div class="slider" [ngClass]="{'slideron': isSelected(option)}">
@@ -62,57 +62,11 @@
             </div>
           </span>
         </ng-container>
-        <span [ngClass]="{'chunkyrow': settings.checkedStyle == 'visual' }" [ngClass]="settings.itemClasses" [style.font-weight]="this.parents.indexOf(option.id)>=0?'bold':'normal'">
+        <span [ngClass]="{'chunkyrow': settings.checkedStyle == 'visual' }" [class.disabled]="isCheckboxDisabled(option)" [ngClass]="settings.itemClasses" [style.font-weight]="this.parents.indexOf(option.id)>=0?'bold':'normal'">
           {{ option.name }}
         </span>
       </a>
       <ng-template #label>{{ option.name }}</ng-template>
-=======
-    <li class="dropdown-item" *ngFor="let option of renderFilteredOptions" (click)="setSelected($event, option)" [ngStyle]="getItemStyle(option)"
-      [ngClass]="option.classes" [class.dropdown-header]="option.isLabel">
-        <a *ngIf="!option.isLabel; else label" href="javascript:;" role="menuitem" tabindex="-1" [style.padding-left]="this.parents.length>0&&this.parents.indexOf(option.id)<0&&'30px'"
-          [ngStyle]="getItemStyleSelectionDisabled()">
-          <ng-container [ngSwitch]="settings.checkedStyle">
-            <input *ngSwitchCase="'checkboxes'" type="checkbox" [checked]="isSelected(option)" (click)="preventCheckboxCheck($event, option)"
-              [disabled]="isCheckboxDisabled(option)" [ngStyle]="getItemStyleSelectionDisabled()" />
-            <span *ngSwitchCase="'glyphicon'" style="width: 16px;" class="glyphicon" [class.glyphicon-ok]="isSelected(option)" [class.glyphicon-lock]="isCheckboxDisabled(option)"></span>
-            <span *ngSwitchCase="'fontawesome'" style="width: 16px;display: inline-block;">
-              <i *ngIf="isSelected(option)" class="fa fa-check" aria-hidden="true"></i>
-              <i *ngIf="isCheckboxDisabled(option)" class="fa fa-lock" aria-hidden="true"></i>
-<<<<<<< HEAD
-            </span>
-          </ng-container>
-          <span [ngClass]="settings.itemClasses" [class.disabled]="isCheckboxDisabled(option)" [style.font-weight]="this.parents.indexOf(option.id)>=0?'bold':'normal'">
-=======
-            </span>
-            <span *ngSwitchCase="'visual'" style="display:block;float:left; border-radius: 0.2em; border: 0.1em solid rgba(44, 44, 44, 0.63);background:rgba(0, 0, 0, 0.1);width: 5.5em;">
-              <div class="slider" [ngClass]="{'slideron': isSelected(option)}">
-                <img *ngIf="option.image != null" [src] = option.image style = "height: 100%; width: 100%; object-fit: contain"/>
-                <div *ngIf="option.image == null" style = "height: 100%; width: 100%;text-align: center; display: table; background-color:rgba(0, 0, 0, 0.74)">
-                  <div class="content_wrapper">
-                  <span style="font-size:3em;color:white" class="glyphicon glyphicon-eye-close"></span>
-                </div>
-                </div>
-            </span>
-          </ng-container>
-<<<<<<< HEAD
-<<<<<<< HEAD
-          <span [ngClass] = "{'chunkyrow': settings.checkedStyle == 'visual' }" [ngClass]="settings.itemClasses" [style.font-weight]="this.parents.indexOf(option.id)>=0?'bold':'normal'">
-=======
-          <span [ngClass]="settings.itemClasses" [class.disabled]="isCheckboxDisabled(option)" [style.font-weight]="this.parents.indexOf(option.id)>=0?'bold':'normal'">
->>>>>>> added disabled classs and input handling
->>>>>>> added disabled classs and input handling
-=======
-          <span [ngClass] = "{'chunkyrow': settings.checkedStyle == 'visual' }" [ngClass]="settings.itemClasses" [class.disabled]="isCheckboxDisabled(option)" [style.font-weight]="this.parents.indexOf(option.id)>=0?'bold':'normal'">
->>>>>>> added to latest master branch the changes i made to my 1.6.0 originally
-            {{ option.name }}
-          </span>
-        </a>
-        <ng-template #label><span [class.disabled]="isCheckboxDisabled()">{{ option.name }}</span></ng-template>
-<<<<<<< HEAD
->>>>>>> added disabled classs and input handling
-=======
->>>>>>> added disabled classs and input handling
     </li>
   </ul>
 </div>

--- a/src/dropdown/dropdown.component.html
+++ b/src/dropdown/dropdown.component.html
@@ -79,13 +79,35 @@
             <span *ngSwitchCase="'fontawesome'" style="width: 16px;display: inline-block;">
               <i *ngIf="isSelected(option)" class="fa fa-check" aria-hidden="true"></i>
               <i *ngIf="isCheckboxDisabled(option)" class="fa fa-lock" aria-hidden="true"></i>
+<<<<<<< HEAD
             </span>
           </ng-container>
           <span [ngClass]="settings.itemClasses" [class.disabled]="isCheckboxDisabled(option)" [style.font-weight]="this.parents.indexOf(option.id)>=0?'bold':'normal'">
+=======
+            </span>
+            <span *ngSwitchCase="'visual'" style="display:block;float:left; border-radius: 0.2em; border: 0.1em solid rgba(44, 44, 44, 0.63);background:rgba(0, 0, 0, 0.1);width: 5.5em;">
+              <div class="slider" [ngClass]="{'slideron': isSelected(option)}">
+                <img *ngIf="option.image != null" [src] = option.image style = "height: 100%; width: 100%; object-fit: contain"/>
+                <div *ngIf="option.image == null" style = "height: 100%; width: 100%;text-align: center; display: table; background-color:rgba(0, 0, 0, 0.74)">
+                  <div class="content_wrapper">
+                  <span style="font-size:3em;color:white" class="glyphicon glyphicon-eye-close"></span>
+                </div>
+                </div>
+            </span>
+          </ng-container>
+<<<<<<< HEAD
+          <span [ngClass] = "{'chunkyrow': settings.checkedStyle == 'visual' }" [ngClass]="settings.itemClasses" [style.font-weight]="this.parents.indexOf(option.id)>=0?'bold':'normal'">
+=======
+          <span [ngClass]="settings.itemClasses" [class.disabled]="isCheckboxDisabled(option)" [style.font-weight]="this.parents.indexOf(option.id)>=0?'bold':'normal'">
+>>>>>>> added disabled classs and input handling
+>>>>>>> added disabled classs and input handling
             {{ option.name }}
           </span>
         </a>
         <ng-template #label><span [class.disabled]="isCheckboxDisabled()">{{ option.name }}</span></ng-template>
+<<<<<<< HEAD
+>>>>>>> added disabled classs and input handling
+=======
 >>>>>>> added disabled classs and input handling
     </li>
   </ul>

--- a/src/dropdown/dropdown.component.html
+++ b/src/dropdown/dropdown.component.html
@@ -96,11 +96,15 @@
             </span>
           </ng-container>
 <<<<<<< HEAD
+<<<<<<< HEAD
           <span [ngClass] = "{'chunkyrow': settings.checkedStyle == 'visual' }" [ngClass]="settings.itemClasses" [style.font-weight]="this.parents.indexOf(option.id)>=0?'bold':'normal'">
 =======
           <span [ngClass]="settings.itemClasses" [class.disabled]="isCheckboxDisabled(option)" [style.font-weight]="this.parents.indexOf(option.id)>=0?'bold':'normal'">
 >>>>>>> added disabled classs and input handling
 >>>>>>> added disabled classs and input handling
+=======
+          <span [ngClass] = "{'chunkyrow': settings.checkedStyle == 'visual' }" [ngClass]="settings.itemClasses" [class.disabled]="isCheckboxDisabled(option)" [style.font-weight]="this.parents.indexOf(option.id)>=0?'bold':'normal'">
+>>>>>>> added to latest master branch the changes i made to my 1.6.0 originally
             {{ option.name }}
           </span>
         </a>

--- a/src/dropdown/dropdown.component.html
+++ b/src/dropdown/dropdown.component.html
@@ -38,6 +38,7 @@
     <li *ngIf="settings.showCheckAll || settings.showUncheckAll" class="dropdown-divider divider"></li>
     <li *ngIf="!renderItems" class="dropdown-item empty">{{ texts.searchNoRenderText }}</li>
     <li *ngIf="renderItems && !renderFilteredOptions.length" class="dropdown-item empty">{{ texts.searchEmptyResult }}</li>
+<<<<<<< HEAD
     <li class="dropdown-item" *ngFor="let option of renderFilteredOptions" [ngClass]="{'active': isSelected(option) }" [ngStyle]="getItemStyle(option)"
       [ngClass]="option.classes" [class.dropdown-header]="option.isLabel" [ssAutofocus]="option !== focusedItem" tabindex="-1"
       (click)="setSelected($event, option)" (keydown.space)="setSelected($event, option)" (keydown.enter)="setSelected($event, option)">
@@ -66,6 +67,26 @@
         </span>
       </a>
       <ng-template #label>{{ option.name }}</ng-template>
+=======
+    <li class="dropdown-item" *ngFor="let option of renderFilteredOptions" (click)="setSelected($event, option)" [ngStyle]="getItemStyle(option)"
+      [ngClass]="option.classes" [class.dropdown-header]="option.isLabel">
+        <a *ngIf="!option.isLabel; else label" href="javascript:;" role="menuitem" tabindex="-1" [style.padding-left]="this.parents.length>0&&this.parents.indexOf(option.id)<0&&'30px'"
+          [ngStyle]="getItemStyleSelectionDisabled()">
+          <ng-container [ngSwitch]="settings.checkedStyle">
+            <input *ngSwitchCase="'checkboxes'" type="checkbox" [checked]="isSelected(option)" (click)="preventCheckboxCheck($event, option)"
+              [disabled]="isCheckboxDisabled(option)" [ngStyle]="getItemStyleSelectionDisabled()" />
+            <span *ngSwitchCase="'glyphicon'" style="width: 16px;" class="glyphicon" [class.glyphicon-ok]="isSelected(option)" [class.glyphicon-lock]="isCheckboxDisabled(option)"></span>
+            <span *ngSwitchCase="'fontawesome'" style="width: 16px;display: inline-block;">
+              <i *ngIf="isSelected(option)" class="fa fa-check" aria-hidden="true"></i>
+              <i *ngIf="isCheckboxDisabled(option)" class="fa fa-lock" aria-hidden="true"></i>
+            </span>
+          </ng-container>
+          <span [ngClass]="settings.itemClasses" [class.disabled]="isCheckboxDisabled(option)" [style.font-weight]="this.parents.indexOf(option.id)>=0?'bold':'normal'">
+            {{ option.name }}
+          </span>
+        </a>
+        <ng-template #label><span [class.disabled]="isCheckboxDisabled()">{{ option.name }}</span></ng-template>
+>>>>>>> added disabled classs and input handling
     </li>
   </ul>
 </div>

--- a/src/dropdown/dropdown.component.ts
+++ b/src/dropdown/dropdown.component.ts
@@ -534,6 +534,7 @@ export class MultiselectDropdown
 
   addChecks(options) {
     let checkedOptions = options
+<<<<<<< HEAD
     .filter(function(option: IMultiSelectOption) {
       if (!
         option.disabled ||
@@ -546,6 +547,15 @@ export class MultiselectDropdown
       return false;
     }.bind(this))
     .map((option: IMultiSelectOption) => option.id);
+=======
+      .filter((option: IMultiSelectOption) => {
+        if (!option.disabled || (this.model.indexOf(option.id) === -1 && !(this.settings.ignoreLabels && option.isLabel))) {
+          this.onAdded.emit(option.id);
+          return true;
+        }
+        return false;
+      }).map((option: IMultiSelectOption) => option.id);
+>>>>>>> added to latest master branch the changes i made to my 1.6.0 originally
     this.model = this.model.concat(checkedOptions);
   }
 

--- a/src/dropdown/dropdown.component.ts
+++ b/src/dropdown/dropdown.component.ts
@@ -535,8 +535,8 @@ export class MultiselectDropdown
   addChecks(options) {
     let checkedOptions = options
     .filter(function(option: IMultiSelectOption) {
-      if (!
-        option.disabled ||
+      if (
+        !option.disabled ||
         (this.model.indexOf(option.id) === -1 &&
         !(this.settings.ignoreLabels && option.isLabel))
       ) {
@@ -615,13 +615,16 @@ export class MultiselectDropdown
   }
 
   preventCheckboxCheck(event: Event, option: IMultiSelectOption) {
-    if (option.disabled || (
-      this.settings.selectionLimit &&
-      !this.settings.autoUnselect &&
-      this.model.length >= this.settings.selectionLimit &&
-      this.model.indexOf(option.id) === -1 &&
-      this.maybePreventDefault(event)
-    )) {
+    if (
+      option.disabled ||
+      (
+        this.settings.selectionLimit &&
+        !this.settings.autoUnselect &&
+        this.model.length >= this.settings.selectionLimit &&
+        this.model.indexOf(option.id) === -1 &&
+        this.maybePreventDefault(event)
+      )
+    ){
       this.maybePreventDefault(event);
     }
   }

--- a/src/dropdown/dropdown.component.ts
+++ b/src/dropdown/dropdown.component.ts
@@ -534,7 +534,6 @@ export class MultiselectDropdown
 
   addChecks(options) {
     let checkedOptions = options
-<<<<<<< HEAD
     .filter(function(option: IMultiSelectOption) {
       if (!
         option.disabled ||
@@ -547,15 +546,7 @@ export class MultiselectDropdown
       return false;
     }.bind(this))
     .map((option: IMultiSelectOption) => option.id);
-=======
-      .filter((option: IMultiSelectOption) => {
-        if (!option.disabled || (this.model.indexOf(option.id) === -1 && !(this.settings.ignoreLabels && option.isLabel))) {
-          this.onAdded.emit(option.id);
-          return true;
-        }
-        return false;
-      }).map((option: IMultiSelectOption) => option.id);
->>>>>>> added to latest master branch the changes i made to my 1.6.0 originally
+
     this.model = this.model.concat(checkedOptions);
   }
 

--- a/src/dropdown/types.ts
+++ b/src/dropdown/types.ts
@@ -1,6 +1,7 @@
 export interface IMultiSelectOption {
   id: any;
   name: string;
+  disabled?: boolean;
   isLabel?: boolean;
   parentId?: any;
   params?: any;


### PR DESCRIPTION
Needed this today for a country list where they still wanted to see the country in the picker but disable the countries where the selection is not allowed .e.g. region locked

### Tested in production
I see this resolves #186 if you want to test it replace your npm line to 
`"angular-2-dropdown-multiselect": "kevcjones/angular-2-dropdown-multiselect#distalt",`

and make sure your imports from `from 'angular-2-dropdown-multiselect/dist';` because obviously i've just pushed the npm dist package to my repo for now.

### Disabled look in font-awesome
![image](https://user-images.githubusercontent.com/696048/33991446-8407697a-e0c6-11e7-9bd8-dbece2057da8.png)

*using the fontawesome rendering but i think i covered the others, both alt renderers use the -lock icon and the native uses the native disabled look*

### Setting the options
``` typescript
this.countryOptions = allCountries.map(c => {
        return {id: c.sys.id, name: c.name, disabled: c.blockAccess};
      });
```

_Disclaimer - sorry for the chaos commits - i had a bit of a fubar with --rebase._