### PR TITLE
[Fix] Keyboard UX

### DIFF
--- a/src/demo/src/app/app.component.css
+++ b/src/demo/src/app/app.component.css
@@ -1,0 +1,5 @@
+:host {
+  display: block;
+  /* To test on pages with scroll */
+  height: 200vh;
+}

--- a/src/dropdown/dropdown.component.html
+++ b/src/dropdown/dropdown.component.html
@@ -1,5 +1,5 @@
 <div class="dropdown" [ngClass]="settings.containerClasses" [class.open]="isVisible" (keyup.esc)="closeDropdown($event)"
-  (keyup.arrowdown)="focusItem(1)" (keyup.arrowup)="focusItem(-1)">
+  (keydown.arrowdown)="focusItem(1, $event)" (keydown.arrowup)="focusItem(-1, $event)">
   <button *ngIf="!isVisible || !(isVisible && settings.enableSearch); else filter" type="button" class="dropdown-toggle" [ngClass]="settings.buttonClasses"
     (click)="toggleDropdown($event)" [disabled]="disabled" [ssAutofocus]="!focusBack">
     {{ title }}
@@ -22,7 +22,7 @@
   <ul #scroller *ngIf="isVisible" class="dropdown-menu" [ngClass]="{'chunkydropdown-menu': settings.checkedStyle == 'visual' }"
     (scroll)="settings.isLazyLoad ? checkScrollPosition($event) : null" (wheel)="settings.stopScrollPropagation ? checkScrollPropagation($event, scroller) : null"
     [class.pull-right]="settings.pullRight" [class.dropdown-menu-right]="settings.pullRight" [style.max-height]="settings.maxHeight"
-    style="display: block; height: auto; overflow-y: auto;">
+    style="display: block; height: auto; overflow-y: auto;" (keydown.tab)="focusItem(1, $event)" (keydown.shift.tab)="focusItem(-1, $event)">
     <li class="dropdown-item check-control check-control-check" *ngIf="settings.showCheckAll && !disabledSelection" (click)="checkAll()">
       <a href="javascript:;" role="menuitem" tabindex="-1">
         <span style="width: 16px;" [ngClass]="{'glyphicon glyphicon-ok': settings.checkedStyle !== 'fontawesome','fa fa-check': settings.checkedStyle === 'fontawesome'}"></span>
@@ -40,7 +40,7 @@
     <li *ngIf="renderItems && !renderFilteredOptions.length" class="dropdown-item empty">{{ texts.searchEmptyResult }}</li>
     <li class="dropdown-item" *ngFor="let option of renderFilteredOptions" [ngClass]="{'active': isSelected(option) }" [ngStyle]="getItemStyle(option)"
       [ngClass]="option.classes" [class.dropdown-header]="option.isLabel" [ssAutofocus]="option !== focusedItem" tabindex="-1"
-      (click)="setSelected($event, option)" (keyup.space)="setSelected($event, option)" (keyup.enter)="setSelected($event, option)">
+      (click)="setSelected($event, option)" (keydown.space)="setSelected($event, option)" (keydown.enter)="setSelected($event, option)">
       <a *ngIf="!option.isLabel; else label" href="javascript:;" role="menuitem" tabindex="-1" [style.padding-left]="this.parents.length>0&&this.parents.indexOf(option.id)<0&&'30px'"
         [ngStyle]="getItemStyleSelectionDisabled()">
         <ng-container [ngSwitch]="settings.checkedStyle">

--- a/src/dropdown/dropdown.component.ts
+++ b/src/dropdown/dropdown.component.ts
@@ -307,16 +307,12 @@ export class MultiselectDropdown implements OnInit, OnChanges, DoCheck, OnDestro
   }
 
   clearSearch(event: Event) {
-    if (event.stopPropagation) {
-      event.stopPropagation();
-    }
+    this.maybeStopPropagation(event);
     this.filterControl.setValue('');
   }
 
   toggleDropdown(e?: Event) {
-    if (e && e.stopPropagation) {
-      e.stopPropagation();
-    }
+    this.maybeStopPropagation(e);
 
     if (this.isVisible) {
       this.focusBack = true;
@@ -342,9 +338,8 @@ export class MultiselectDropdown implements OnInit, OnChanges, DoCheck, OnDestro
     }
 
     if (!this.disabledSelection) {
-      if (_event.stopPropagation) {
-        _event.stopPropagation();
-      }
+      this.maybeStopPropagation(_event);
+      this.maybePreventDefault(_event);
       const index = this.model.indexOf(option.id);
       const isAtSelectionLimit = this.settings.selectionLimit > 0 && this.model.length >= this.settings.selectionLimit;
       const removeItem = (idx, id): void => {
@@ -501,9 +496,9 @@ export class MultiselectDropdown implements OnInit, OnChanges, DoCheck, OnDestro
     if (this.settings.selectionLimit && !this.settings.autoUnselect &&
       this.model.length >= this.settings.selectionLimit &&
       this.model.indexOf(option.id) === -1 &&
-      event.preventDefault
+      this.maybePreventDefault(event)
     ) {
-      event.preventDefault();
+      this.maybePreventDefault(event);
     }
   }
 
@@ -530,7 +525,7 @@ export class MultiselectDropdown implements OnInit, OnChanges, DoCheck, OnDestro
 
     if ((ev.deltaY > 0 && scrollTop + scrollElementHeight >= scrollHeight) || (ev.deltaY < 0 && scrollTop <= 0)) {
       ev = ev || window.event;
-      ev.preventDefault && ev.preventDefault();
+      this.maybePreventDefault(ev);
       ev.returnValue = false;
     }
   }
@@ -544,10 +539,12 @@ export class MultiselectDropdown implements OnInit, OnChanges, DoCheck, OnDestro
     });
   }
 
-  focusItem(dir: number) {
+  focusItem(dir: number, e?: Event) {
     if (!this.isVisible) {
       return;
     }
+
+    this.maybePreventDefault(e);
 
     const idx = this.filteredOptions.indexOf(this.focusedItem);
 
@@ -562,6 +559,18 @@ export class MultiselectDropdown implements OnInit, OnChanges, DoCheck, OnDestro
       : nextIdx % this.filteredOptions.length;
 
     this.focusedItem = this.filteredOptions[newIdx];
+  }
+
+  private maybePreventDefault(e?: { preventDefault?: Function }) {
+    if (e && e.preventDefault) {
+      e.preventDefault();
+    }
+  }
+
+  private maybeStopPropagation(e?: { stopPropagation?: Function }) {
+    if (e && e.stopPropagation) {
+      e.stopPropagation();
+    }
   }
 
 }


### PR DESCRIPTION
This PR fixes issues with keyboard access (via arrow keys and space selection).

Previously when you were on page with scroll and trying to navigate items via arrow key the whole page was jumping along because events were not prevented - now it's fixed.

Now `Tab` and `Shift + Tab` keyboard strokes also handled same way as arrow up/down keys.

Also demo page was updated to have scrolling to test this kind of interactions.