### PR TITLE
feat: Allow to set focusBack option in settings

### DIFF
--- a/README.md
+++ b/README.md
@@ -138,6 +138,7 @@ myOptions: IMultiSelectOption[] = [
 | selectAddedValues    | Additional lazy loaded ```Select All``` values are checked when added on scrolling | false             |
 | ignoreLabels         | Ignore label options when counting selected options                | false             |
 | maintainSelectionOrderInTitle | The title will show selections in the order they were selected   | false             |
+| focusBack | Set the focus back to the input control when the dropdown closed              | true             |
 
 ### Texts
 | Text Item             | Description                                | Default Value     |

--- a/src/dropdown/dropdown.component.ts
+++ b/src/dropdown/dropdown.component.ts
@@ -69,6 +69,7 @@ export class MultiselectDropdown
   @Input() texts: IMultiSelectTexts;
   @Input() disabled: boolean = false;
   @Input() disabledSelection: boolean = false;
+
   @Output() selectionLimitReached = new EventEmitter();
   @Output() dropdownClosed = new EventEmitter();
   @Output() dropdownOpened = new EventEmitter();
@@ -76,6 +77,10 @@ export class MultiselectDropdown
   @Output() onRemoved = new EventEmitter();
   @Output() onLazyLoad = new EventEmitter();
   @Output() onFilter: Observable<string> = this.filterControl.valueChanges;
+
+  get focusBack():boolean{
+    return this.settings.focusBack && this._focusBack
+  }
 
   @HostListener('document: click', ['$event.target'])
   @HostListener('document: touchstart', ['$event.target'])
@@ -90,7 +95,7 @@ export class MultiselectDropdown
     }
     if (!parentFound) {
       this.isVisible = false;
-      this.focusBack = true;
+      this._focusBack = true;
       this.dropdownClosed.emit();
     }
   }
@@ -117,7 +122,7 @@ export class MultiselectDropdown
   checkAllSearchRegister = new Set();
   checkAllStatus = false;
   loadedValueIds = [];
-  focusBack = false;
+  _focusBack = false;
   focusedItem: IMultiSelectOption | undefined;
 
   defaultSettings: IMultiSelectSettings = {
@@ -146,6 +151,7 @@ export class MultiselectDropdown
     selectAddedValues: false,
     ignoreLabels: false,
     maintainSelectionOrderInTitle: false,
+    focusBack: true
   };
   defaultTexts: IMultiSelectTexts = {
     checkAll: 'Check all',
@@ -363,7 +369,7 @@ export class MultiselectDropdown
     this.maybeStopPropagation(e);
 
     if (this.isVisible) {
-      this.focusBack = true;
+      this._focusBack = true;
     }
 
     this.isVisible = !this.isVisible;

--- a/src/dropdown/types.ts
+++ b/src/dropdown/types.ts
@@ -62,6 +62,11 @@ export interface IMultiSelectSettings {
    * If activated, the title will show selections in the order they were selected.
    */
   maintainSelectionOrderInTitle?: boolean;
+  /**
+   * @default true
+   * Set the focus back to the input control when the dropdown closed
+   */
+  focusBack?: boolean;
 }
 
 export interface IMultiSelectTexts {


### PR DESCRIPTION
I would like set this functionality from settings, because in my use case 
 - when user select 'Other' options then popup open and user have to set the new value. 

The original behaviour removed the focus from the pop-up input.