### PR TITLE
fix: checkbox selection state

### DIFF
--- a/src/dropdown/dropdown.component.ts
+++ b/src/dropdown/dropdown.component.ts
@@ -301,6 +301,7 @@ export class MultiselectDropdownComponent
       this.prevModel = this.model;
       this.onModelChange(this.model);
       this.onModelTouched();
+      this.cdRef.markForCheck();
     }
   }
 
@@ -395,7 +396,11 @@ export class MultiselectDropdownComponent
       return;
     }
 
-    if (!this.disabledSelection) {
+    if (this.disabledSelection) {
+      return;
+    }
+
+    setTimeout(()=>{
       this.maybeStopPropagation(_event);
       this.maybePreventDefault(_event);
       const index = this.model.indexOf(option.id);
@@ -481,7 +486,8 @@ export class MultiselectDropdownComponent
       }
       this.model = this.model.slice();
       this.fireModelChange();
-    }
+
+    }, 0)
   }
 
   updateNumSelected() {


### PR DESCRIPTION
on Mac with Chrome 64/65/67 when the user clicked in the checkbox the selection state of the option in changed, but checkbox state remained the old state.

This PR tested on Mac with Chrome 64/65/67 and Firefox 57/58/59