### PR TITLE
Support fontawesome 4 usage

### DIFF
--- a/src/dropdown/dropdown.component.html
+++ b/src/dropdown/dropdown.component.html
@@ -24,12 +24,12 @@
     </div>
     <a role="menuitem" href="javascript:;" tabindex="-1" class="dropdown-item check-control check-control-check" *ngIf="settings.showCheckAll && !disabledSelection"
       (click)="checkAll()">
-      <span style="width: 16px;" [ngClass]="{'glyphicon glyphicon-ok': settings.checkedStyle !== 'fontawesome','fa fa-check': settings.checkedStyle === 'fontawesome'}"></span>
+      <span style="width: 16px;"><span [ngClass]="{'glyphicon glyphicon-ok': settings.checkedStyle !== 'fontawesome','fa fa-check': settings.checkedStyle === 'fontawesome'}"></span></span>
       {{ texts.checkAll }}
     </a>
     <a role="menuitem" href="javascript:;" tabindex="-1" class="dropdown-item check-control check-control-uncheck" *ngIf="settings.showUncheckAll && !disabledSelection"
       (click)="uncheckAll()">
-      <span style="width: 16px;" [ngClass]="{'glyphicon glyphicon-remove': settings.checkedStyle !== 'fontawesome','fa fa-times': settings.checkedStyle === 'fontawesome'}"></span>
+      <span style="width: 16px;"><span [ngClass]="{'glyphicon glyphicon-remove': settings.checkedStyle !== 'fontawesome','fa fa-times': settings.checkedStyle === 'fontawesome'}"></span></span>
       {{ texts.uncheckAll }}
     </a>
     <a *ngIf="settings.showCheckAll || settings.showUncheckAll" href="javascript:;" class="dropdown-divider divider"></a>
@@ -45,8 +45,8 @@
             [disabled]="isCheckboxDisabled(option)" [ngStyle]="getItemStyleSelectionDisabled()" />
           <span *ngSwitchCase="'glyphicon'" style="width: 16px;" class="glyphicon" [class.glyphicon-ok]="isSelected(option)" [class.glyphicon-lock]="isCheckboxDisabled(option)"></span>
           <span *ngSwitchCase="'fontawesome'" style="width: 16px;display: inline-block;">
-            <i *ngIf="isSelected(option)" class="fa fa-check" aria-hidden="true"></i>
-            <i *ngIf="isCheckboxDisabled(option)" class="fa fa-lock" aria-hidden="true"></i>
+            <span *ngIf="isSelected(option)"><i class="fa fa-check" aria-hidden="true"></i></span>
+            <span *ngIf="isCheckboxDisabled(option)"><i class="fa fa-lock" aria-hidden="true"></i></span>
           </span>
           <span *ngSwitchCase="'visual'" style="display:block;float:left; border-radius: 0.2em; border: 0.1em solid rgba(44, 44, 44, 0.63);background:rgba(0, 0, 0, 0.1);width: 5.5em;">
             <div class="slider" [ngClass]="{'slideron': isSelected(option)}">


### PR DESCRIPTION
Greetings!

My project used Font Awesome v4 and we love this project but it currently doesn't support it. This is because in the newer versions of FA-V4 they replace the element that uses the typical `fa-*` classes with an `svg` instead.

This means if you previously had conditions like `*ngIf` on elements that had these classes they would be eaten up in the process which was leading to bugs like checkmarks staying around even when unselected.

Fairly simple fix. Let me know if you need anything else and how soon we can get this in a minor version bump!

Thanks