### PR TITLE
 Only uncheck filtered items

### DIFF
--- a/demo/src/app/dummy.component.html
+++ b/demo/src/app/dummy.component.html
@@ -7,7 +7,7 @@
   </p>
 
   <p>
-    With search:
+    With search and buttons:
     <ss-multiselect-dropdown [options]="data.options" [settings]="settings" [ngModel]="data.selectedItems"></ss-multiselect-dropdown>
   </p>
 </div>

--- a/demo/src/app/dummy.component.ts
+++ b/demo/src/app/dummy.component.ts
@@ -14,5 +14,7 @@ export class DummyComponent {
 
   settings: IMultiSelectSettings = {
     enableSearch: true,
+    showCheckAll: true,
+    showUncheckAll: true
   };
 }

--- a/src/dropdown/dropdown.component.ts
+++ b/src/dropdown/dropdown.component.ts
@@ -595,7 +595,7 @@ export class MultiselectDropdownComponent
         ? this.model
         : this.filteredOptions.map((option: IMultiSelectOption) => option.id);
       // set unchecked options only to the ones that were checked
-      unCheckedOptions = checkedOptions.filter(item => this.model.indexOf(item) > -1);
+      unCheckedOptions = checkedOptions.filter(item => unCheckedOptions.indexOf(item) > -1);
       this.model = this.model.filter((id: number) => {
         if (
           (unCheckedOptions.indexOf(id) < 0 &&


### PR DESCRIPTION
This was ennoying us for a while...

When you filter for items and click `check all`, all filtered items got fixed (and no others). But when clicking  `uncheck all`, also all unfiltered items, aka all items, got unchecked. This PR solves this inconsistency. 

PS: there should really be a possibility to write unit tests...