### PR TITLE
fix(isCheckboxDisabled): isLabel option breaks disabled check

### DIFF
--- a/src/dropdown/dropdown.component.html
+++ b/src/dropdown/dropdown.component.html
@@ -65,7 +65,7 @@
         </span>
       </span>
       <ng-template #label>
-        <span [class.disabled]="isCheckboxDisabled()">{{ option.name }}</span>
+        <span [class.disabled]="isCheckboxDisabled(option)">{{ option.name }}</span>
       </ng-template>
     </a>
   </div>

--- a/src/dropdown/dropdown.component.ts
+++ b/src/dropdown/dropdown.component.ts
@@ -642,8 +642,8 @@ export class MultiselectDropdownComponent
     }
   }
 
-  isCheckboxDisabled(option: IMultiSelectOption): boolean {
-    return this.disabledSelection || option.disabled;
+  isCheckboxDisabled(option?: IMultiSelectOption): boolean {
+    return this.disabledSelection || option && option.disabled;
   }
 
   checkScrollPosition(ev) {


### PR DESCRIPTION
adding `isLabel` to an option throws an error. This is because the `isCheckboxDisabled` method looks for `disabled`'s value on an option item of undefined as there is never an option sent as the param inside the template. Simply adding the option as a param inside the template fixes this, but I adapted the `isCheckboxDisabled` method to make it future proof too. 