### PR TITLE
Update peer dependencies versions

### DIFF
--- a/src/package.json
+++ b/src/package.json
@@ -21,9 +21,9 @@
   },
   "homepage": "http://softsimon.github.io/angular-2-dropdown-multiselect",
   "peerDependencies": {
-    "@angular/common": "^5.2.9",
-    "@angular/core": "^5.2.9",
-    "@angular/forms": "^5.2.9",
+    "@angular/common": "^6.0.0",
+    "@angular/core": "^6.0.0",
+    "@angular/forms": "^6.0.0",
     "tslib": "^1.6.1"
   }
 }


### PR DESCRIPTION
When installing the angular-2-dropdown-multiselect there are warnings about the peer dependencies.

With this update of the peer dependencies versions there shouldn't be a warning.