### PR TITLE
Fix AOT fullTemplateTypeCheck compile errors

### DIFF
--- a/demo/e2e/tsconfig.e2e.json
+++ b/demo/e2e/tsconfig.e2e.json
@@ -10,5 +10,8 @@
       "jasminewd2",
       "node"
     ]
+  },
+  "angularCompilerOptions": {
+    "fullTemplateTypeCheck": true
   }
 }

--- a/demo/src/tsconfig.app.json
+++ b/demo/src/tsconfig.app.json
@@ -7,6 +7,9 @@
     "types": [],
     "skipLibCheck": true
   },
+  "angularCompilerOptions": {
+    "fullTemplateTypeCheck": true
+  },
   "exclude": [
     "test.ts",
     "**/*.spec.ts"

--- a/demo/src/tsconfig.spec.json
+++ b/demo/src/tsconfig.spec.json
@@ -10,6 +10,9 @@
       "node"
     ]
   },
+  "angularCompilerOptions": {
+    "fullTemplateTypeCheck": true
+  },
   "files": [
     "test.ts"
   ],

--- a/src/dropdown/dropdown.component.html
+++ b/src/dropdown/dropdown.component.html
@@ -1,4 +1,4 @@
-<div class="dropdown" [ngClass]="settings.containerClasses" [class.open]="isVisible" (offClick)="clickedOutside($event)">
+<div class="dropdown" [ngClass]="settings.containerClasses" [class.open]="isVisible" (offClick)="clickedOutside()">
   <button type="button" class="dropdown-toggle" [ngClass]="settings.buttonClasses" (click)="toggleDropdown($event)" [disabled]="disabled"
     [ssAutofocus]="!focusBack">
     {{ title }}

--- a/src/dropdown/off-click.directive.ts
+++ b/src/dropdown/off-click.directive.ts
@@ -28,14 +28,14 @@ export class OffClickDirective {
   }
 
   @HostListener('document:click', ['$event']) 
-  private onDocumentClick(event: MouseEvent): void {
+  public onDocumentClick(event: MouseEvent): void {
     if (event !== this._clickEvent) {
       this.onOffClick.emit(event);
     }
   }
 
   @HostListener('document:touchstart', ['$event'])
-  private onDocumentTouch(event: TouchEvent): void {
+  public onDocumentTouch(event: TouchEvent): void {
     if (event !== this._touchEvent) {
       this.onOffClick.emit(event);
     }

--- a/src/dropdown/types.ts
+++ b/src/dropdown/types.ts
@@ -34,7 +34,7 @@ export interface IMultiSelectSettings {
    * Should be less than searchMaxLimit to take effect
    */
   searchMaxRenderedItems?: number;
-  checkedStyle?: 'checkboxes' | 'glyphicon' | 'fontawesome';
+  checkedStyle?: 'checkboxes' | 'glyphicon' | 'fontawesome' | 'visual';
   buttonClasses?: string;
   itemClasses?: string;
   containerClasses?: string;


### PR DESCRIPTION
This PR fixes the following compile errors that occur if you try to `ng build --aot` an application with `fullTemplateTypeCheck: true`:

`ERROR in src/dropdown/dropdown.component.html(62,15): : Operator '==' cannot be applied to types '"checkboxes" | "glyphicon" | "fontawesome"' and '"visual"'.
src/dropdown/dropdown.component.html(7,58): : Operator '==' cannot be applied to types '"checkboxes" | "glyphicon" | "fontawesome"' and '"visual"'.
src/dropdown/dropdown.component.html(1,1): : Directive OffClickDirective, Property 'onDocumentClick' is private and only accessible within class 'OffClickDirective'.
src/dropdown/dropdown.component.html(1,1): : Directive OffClickDirective, Property 'onDocumentTouch' is private and only accessible within class 'OffClickDirective'.
src/dropdown/dropdown.component.html(1,86): : Expected 0 arguments, but got 1.`